### PR TITLE
Run fewer tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,13 +1,13 @@
 name: Run tests
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   run-tests:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Node v${{ matrix.node-version }} (${{ matrix.os }})


### PR DESCRIPTION
We do not need to check against 10.x or 12.x